### PR TITLE
[Feature] SoundManager에 음악 재생 기능 추가

### DIFF
--- a/Assets/01. Scenes/KMC/Merge.unity
+++ b/Assets/01. Scenes/KMC/Merge.unity
@@ -8820,7 +8820,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 320795358004260300, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 320795358004260300, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -8840,7 +8840,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 507584573640218982, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 156.25
       objectReference: {fileID: 0}
     - target: {fileID: 507584573640218982, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -8860,7 +8860,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 978717875404537221, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 156.25
       objectReference: {fileID: 0}
     - target: {fileID: 1210073625012795827, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchorMax.y
@@ -8968,7 +8968,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2755784052329615216, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 156.25
       objectReference: {fileID: 0}
     - target: {fileID: 2755784052329615216, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -9048,7 +9048,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3601842880741710729, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 156.25
       objectReference: {fileID: 0}
     - target: {fileID: 3601842880741710729, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -9108,7 +9108,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4250458231020627005, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 4250458231020627005, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -9208,7 +9208,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4923421810534849273, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 4923421810534849273, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -9228,7 +9228,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5128332077379104339, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 156.25
       objectReference: {fileID: 0}
     - target: {fileID: 5128332077379104339, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -9292,7 +9292,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6100589638765025829, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 6100589638765025829, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -9392,7 +9392,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7306612698170985711, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 7306612698170985711, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -9536,7 +9536,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8260901835921758230, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 8260901835921758230, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -9576,7 +9576,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8765243243278542754, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 156.25
       objectReference: {fileID: 0}
     - target: {fileID: 8765243243278542754, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -10036,7 +10036,7 @@ MonoBehaviour:
   - {fileID: 1031547556}
   - {fileID: 1484994809}
   dialogueSpeed: 1
-  fadeSpeed: 1
+  transitionDuration: 0.5
   storyBackgroundObject: {fileID: 0}
   battleBackgroundObject: {fileID: 0}
 --- !u!1 &552572904
@@ -16304,7 +16304,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 320795358004260300, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 320795358004260300, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -16324,7 +16324,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 507584573640218982, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 156.25
       objectReference: {fileID: 0}
     - target: {fileID: 507584573640218982, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -16344,7 +16344,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 978717875404537221, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 156.25
       objectReference: {fileID: 0}
     - target: {fileID: 1210073625012795827, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchorMax.y
@@ -16452,7 +16452,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2755784052329615216, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 156.25
       objectReference: {fileID: 0}
     - target: {fileID: 2755784052329615216, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -16532,7 +16532,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3601842880741710729, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 156.25
       objectReference: {fileID: 0}
     - target: {fileID: 3601842880741710729, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -16592,7 +16592,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4250458231020627005, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 4250458231020627005, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -16692,7 +16692,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4923421810534849273, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 4923421810534849273, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -16712,7 +16712,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5128332077379104339, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 156.25
       objectReference: {fileID: 0}
     - target: {fileID: 5128332077379104339, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -16776,7 +16776,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6100589638765025829, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 6100589638765025829, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -16876,7 +16876,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7306612698170985711, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 7306612698170985711, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -17020,7 +17020,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8260901835921758230, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 8260901835921758230, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -17060,7 +17060,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8765243243278542754, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 156.25
       objectReference: {fileID: 0}
     - target: {fileID: 8765243243278542754, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -19216,6 +19216,7 @@ GameObject:
   m_Component:
   - component: {fileID: 919981845}
   - component: {fileID: 919981846}
+  - component: {fileID: 919981847}
   m_Layer: 0
   m_Name: SoundManager
   m_TagString: Untagged
@@ -19255,6 +19256,104 @@ MonoBehaviour:
   masterVolumeSlider: {fileID: 666070203}
   bgmVolumeSlider: {fileID: 601399734}
   applyCount: 0
+  bgmSources: []
+  effectSources: []
+--- !u!82 &919981847
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 919981844}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1 &930973509
 GameObject:
   m_ObjectHideFlags: 0
@@ -20930,7 +21029,7 @@ MonoBehaviour:
   - {fileID: 1031547556}
   - {fileID: 1484994809}
   dialogueSpeed: 1
-  fadeSpeed: 1
+  transitionDuration: 0.5
   storyBackgroundObject: {fileID: 0}
   battleBackgroundObject: {fileID: 0}
   skipButton: {fileID: 1130054972}
@@ -23446,6 +23545,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 869359cc22fcddc4d85db1e98edd0b0b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  alertPanel: {fileID: 0}
+  isLoadButton: 0
 --- !u!114 &1099207032
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -23928,11 +24029,13 @@ MonoBehaviour:
     currentEvent: {fileID: 0}
     processableMainEventList: []
     processableSubEventList: []
+    delayDictionary: []
     items: []
     selectedResolutionIndex: 0
     fullscreen: 0
     masterVolume: 0
     bgmVolume: 0
+  isLoaded: 0
 --- !u!4 &1126983176
 Transform:
   m_ObjectHideFlags: 0
@@ -30346,7 +30449,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 320795358004260300, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 320795358004260300, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -30366,7 +30469,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 507584573640218982, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 156.25
       objectReference: {fileID: 0}
     - target: {fileID: 507584573640218982, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -30386,7 +30489,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 978717875404537221, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 156.25
       objectReference: {fileID: 0}
     - target: {fileID: 1210073625012795827, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchorMax.y
@@ -30494,7 +30597,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2755784052329615216, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 156.25
       objectReference: {fileID: 0}
     - target: {fileID: 2755784052329615216, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -30574,7 +30677,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3601842880741710729, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 156.25
       objectReference: {fileID: 0}
     - target: {fileID: 3601842880741710729, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -30634,7 +30737,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4250458231020627005, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 4250458231020627005, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -30734,7 +30837,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4923421810534849273, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 4923421810534849273, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -30754,7 +30857,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5128332077379104339, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 156.25
       objectReference: {fileID: 0}
     - target: {fileID: 5128332077379104339, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -30818,7 +30921,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6100589638765025829, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 6100589638765025829, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -30918,7 +31021,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7306612698170985711, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 7306612698170985711, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -31062,7 +31165,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8260901835921758230, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 8260901835921758230, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -31102,7 +31205,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8765243243278542754, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 156.25
       objectReference: {fileID: 0}
     - target: {fileID: 8765243243278542754, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -39010,147 +39113,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f6b8ec2ce41f8524c994161b6a053195, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  items:
-  - type: 1
-    name: Error
-    tag: Error
-    count: 0
-  - type: 1
-    name: "\uBE75"
-    tag: "\uC74C\uC2DD"
-    count: 1
-  - type: 1
-    name: "\uC1A1\uC774\uBC84\uC12F"
-    tag: "\uC74C\uC2DD"
-    count: 1
-  - type: 1
-    name: "\uACE0\uAE30"
-    tag: "\uC74C\uC2DD"
-    count: 1
-  - type: 1
-    name: "\uACE0\uAE30?"
-    tag: "\uC74C\uC2DD"
-    count: 1
-  - type: 1
-    name: "\uC0AC\uD0D5"
-    tag: "\uAC04\uC2DD"
-    count: 1
-  - type: 1
-    name: "\uCD08\uCF5C\uB9BF"
-    tag: "\uAC04\uC2DD"
-    count: 1
-  - type: 1
-    name: "\uAC74\uBE75"
-    tag: "\uAC04\uC2DD"
-    count: 1
-  - type: 1
-    name: "\uAC1C\uAECC"
-    tag: "\uAC1C\uAECC"
-    count: 1
-  - type: 1
-    name: "\uCF54\uD2B8"
-    tag: "\uC678\uD22C"
-    count: 1
-  - type: 1
-    name: "\uAC00\uC6B4"
-    tag: "\uC678\uD22C"
-    count: 1
-  - type: 1
-    name: "\uAD70\uBCF5"
-    tag: "\uAD70\uBCF5"
-    count: 1
-  - type: 1
-    name: "\uC6B0\uC0B0"
-    tag: "\uC6B0\uC0B0"
-    count: 1
-  - type: 1
-    name: "\uD574\uC5F4\uC81C"
-    tag: "\uC57D"
-    count: 1
-  - type: 1
-    name: "\uBD95\uB300"
-    tag: "\uC57D"
-    count: 1
-  - type: 1
-    name: "\uB3C8"
-    tag: "\uC7AC\uD654"
-    count: 1
-  - type: 1
-    name: "\uB2E4\uC774\uC544\uBAAC\uB4DC"
-    tag: "\uC7AC\uD654"
-    count: 1
-  - type: 1
-    name: "\uC2DD\uCE7C"
-    tag: "\uCE7C"
-    count: 1
-  - type: 1
-    name: "\uAD8C\uCD1D"
-    tag: "\uCD1D"
-    count: 1
-  - type: 1
-    name: "\uD39C\uB358\uD2B8"
-    tag: "\uD39C\uB358\uD2B8"
-    count: 1
-  - type: 1
-    name: "\uD06C\uB808\uC6A9"
-    tag: "\uD06C\uB808\uC6A9"
-    count: 1
-  - type: 1
-    name: "\uAC1C"
-    tag: "\uBC18\uB824\uB3D9\uBB3C"
-    count: 1
-  - type: 0
-    name: "\uADFC\uB825"
-    tag: "\uADFC\uB825"
-    count: 1
-  - type: 0
-    name: "\uBBFC\uCCA9\uC131"
-    tag: "\uBBFC\uCCA9\uC131"
-    count: 1
-  - type: 0
-    name: "\uAD00\uCC30\uB825"
-    tag: "\uAD00\uCC30\uB825"
-    count: 1
-  - type: 0
-    name: "\uCCA0\uD559"
-    tag: "\uCCA0\uD559"
-    count: 1
-  - type: 0
-    name: "\uAC10\uC131"
-    tag: "\uAC10\uC131"
-    count: 1
-  - type: 0
-    name: "\uD1B5\uCF8C\uD568"
-    tag: "\uD1B5\uCF8C\uD568"
-    count: 1
-  - type: 0
-    name: "\uC601\uC5B4 \uC2E4\uB825"
-    tag: "\uC601\uC5B4 \uC2E4\uB825"
-    count: 1
-  - type: 0
-    name: "\uADFC\uC131"
-    tag: "\uADFC\uC131"
-    count: 1
-  - type: 0
-    name: "\uD6C4\uAC01"
-    tag: "\uD6C4\uAC01"
-    count: 1
-  - type: 0
-    name: "\uC544\uB9AC\uB9C8\uC640\uC758 \uCE5C\uBD84"
-    tag: "\uC544\uB9AC\uB9C8\uC640\uC758 \uCE5C\uBD84"
-    count: 1
-  - type: 0
-    name: "\uBCF4\uC721\uC6D0\uACFC\uC758 \uCE5C\uBD84"
-    tag: "\uBCF4\uC721\uC6D0\uACFC\uC758 \uCE5C\uBD84"
-    count: 1
-  - type: 0
-    name: "\uAC10\uAE30"
-    tag: "\uAC10\uAE30"
-    count: 1
-  - type: 0
-    name: "\uCD9C\uD608"
-    tag: "\uCD9C\uD608"
-    count: 1
 --- !u!1 &1955942693
 GameObject:
   m_ObjectHideFlags: 0
@@ -39725,7 +39687,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 615529619156790423, guid: f13cf976d1ca6b8419a5f9458e64ae8b, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 615529619156790423, guid: f13cf976d1ca6b8419a5f9458e64ae8b, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -39773,7 +39735,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1388518331938056398, guid: f13cf976d1ca6b8419a5f9458e64ae8b, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 281.25
       objectReference: {fileID: 0}
     - target: {fileID: 1388518331938056398, guid: f13cf976d1ca6b8419a5f9458e64ae8b, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -39809,7 +39771,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1586184535818989739, guid: f13cf976d1ca6b8419a5f9458e64ae8b, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 281.25
       objectReference: {fileID: 0}
     - target: {fileID: 1586184535818989739, guid: f13cf976d1ca6b8419a5f9458e64ae8b, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -39865,7 +39827,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2309971308781174815, guid: f13cf976d1ca6b8419a5f9458e64ae8b, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 281.25
       objectReference: {fileID: 0}
     - target: {fileID: 2309971308781174815, guid: f13cf976d1ca6b8419a5f9458e64ae8b, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -39949,7 +39911,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4400738759247151835, guid: f13cf976d1ca6b8419a5f9458e64ae8b, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 4400738759247151835, guid: f13cf976d1ca6b8419a5f9458e64ae8b, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -40033,7 +39995,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5463433260993244936, guid: f13cf976d1ca6b8419a5f9458e64ae8b, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 281.25
       objectReference: {fileID: 0}
     - target: {fileID: 5463433260993244936, guid: f13cf976d1ca6b8419a5f9458e64ae8b, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -40053,7 +40015,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5772996140401503057, guid: f13cf976d1ca6b8419a5f9458e64ae8b, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 5772996140401503057, guid: f13cf976d1ca6b8419a5f9458e64ae8b, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -40085,7 +40047,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6150664857582138164, guid: f13cf976d1ca6b8419a5f9458e64ae8b, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 6150664857582138164, guid: f13cf976d1ca6b8419a5f9458e64ae8b, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -40121,7 +40083,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7158020659629720448, guid: f13cf976d1ca6b8419a5f9458e64ae8b, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 7158020659629720448, guid: f13cf976d1ca6b8419a5f9458e64ae8b, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -40217,7 +40179,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9100191421375463748, guid: f13cf976d1ca6b8419a5f9458e64ae8b, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 281.25
       objectReference: {fileID: 0}
     - target: {fileID: 9100191421375463748, guid: f13cf976d1ca6b8419a5f9458e64ae8b, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -43158,6 +43120,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 869359cc22fcddc4d85db1e98edd0b0b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  alertPanel: {fileID: 0}
+  isLoadButton: 0
 --- !u!1001 &2136048979
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -43448,7 +43412,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 320795358004260300, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 320795358004260300, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -43468,7 +43432,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 507584573640218982, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 156.25
       objectReference: {fileID: 0}
     - target: {fileID: 507584573640218982, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -43488,7 +43452,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 978717875404537221, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 156.25
       objectReference: {fileID: 0}
     - target: {fileID: 1210073625012795827, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchorMax.y
@@ -43596,7 +43560,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2755784052329615216, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 156.25
       objectReference: {fileID: 0}
     - target: {fileID: 2755784052329615216, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -43676,7 +43640,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3601842880741710729, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 156.25
       objectReference: {fileID: 0}
     - target: {fileID: 3601842880741710729, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -43736,7 +43700,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4250458231020627005, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 4250458231020627005, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -43836,7 +43800,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4923421810534849273, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 4923421810534849273, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -43856,7 +43820,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5128332077379104339, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 156.25
       objectReference: {fileID: 0}
     - target: {fileID: 5128332077379104339, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -43920,7 +43884,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6100589638765025829, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 6100589638765025829, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -44020,7 +43984,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7306612698170985711, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 7306612698170985711, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -44164,7 +44128,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8260901835921758230, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 155.5
       objectReference: {fileID: 0}
     - target: {fileID: 8260901835921758230, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -44204,7 +44168,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8765243243278542754, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 156.25
       objectReference: {fileID: 0}
     - target: {fileID: 8765243243278542754, guid: 75fdabc16d41bc04fa3893ed0b15e77a, type: 3}
       propertyPath: m_AnchoredPosition.y

--- a/Assets/01. Scenes/KMC/Merge.unity
+++ b/Assets/01. Scenes/KMC/Merge.unity
@@ -19256,7 +19256,7 @@ MonoBehaviour:
   masterVolumeSlider: {fileID: 666070203}
   bgmVolumeSlider: {fileID: 601399734}
   applyCount: 0
-  bgmSources: []
+  bgmSource: {fileID: 0}
   effectSources: []
 --- !u!82 &919981847
 AudioSource:
@@ -40133,6 +40133,10 @@ PrefabInstance:
       propertyPath: m_Camera
       value: 
       objectReference: {fileID: 476913965}
+    - target: {fileID: 8192855279024533039, guid: f13cf976d1ca6b8419a5f9458e64ae8b, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 8642091009161287679, guid: f13cf976d1ca6b8419a5f9458e64ae8b, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0

--- a/Assets/02. Scripts/Story/Managers/SoundManager.cs
+++ b/Assets/02. Scripts/Story/Managers/SoundManager.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -22,6 +20,50 @@ public class SoundManager : MonoBehaviour
 
     public int applyCount = 0;
 
+    [Header("재생")]
+    // BGM 재생기 개수
+    private const int bgmAudioCount = 1;
+    private const int effectAudioCount = 5;
+
+    [SerializeField]
+    private AudioSource[] bgmSources;
+    [SerializeField]
+    private AudioSource[] effectSources;
+
+    private void AssignAudioComponent()
+    {
+        // 모든 컴포넌트를 가져온다.
+        AudioSource[] audioSources = GetComponents<AudioSource>();
+
+        // 모자라면 재생기를 생성한다.
+        if (audioSources.Length < bgmAudioCount + effectAudioCount)
+        {
+            // 모자란 만큼 생성
+            for(int i = audioSources.Length; i < bgmAudioCount + effectAudioCount; ++i)
+            {
+                gameObject.AddComponent<AudioSource>();
+            }
+
+            // 다시 컴포넌트들을 가져온다.
+            audioSources = GetComponents<AudioSource>();
+        }
+
+
+        // BGM 재생기 할당
+        bgmSources = new AudioSource[bgmAudioCount];
+        for (int i = 0; i < bgmAudioCount; ++i)
+        {
+            bgmSources[i] = audioSources[i];
+        }
+
+        // 효과음 재생기 할당
+        effectSources = new AudioSource[effectAudioCount];
+        for (int i = 0; i < effectAudioCount; ++i)
+        {
+            effectSources[i] = audioSources[bgmAudioCount + i - 1];
+        }
+    }
+
     private void Awake()
     {
         Instance = this;
@@ -34,7 +76,9 @@ public class SoundManager : MonoBehaviour
         masterVolumeSlider.onValueChanged.AddListener(SetMasterVolume); 
         bgmVolumeSlider.onValueChanged.AddListener(SetBGMVolume);
 
-        UpdateAudioSources(); 
+        UpdateAudioSources();
+
+        AssignAudioComponent();
     }
 
     // 전체 음량 슬라이더 값 변경 시 호출

--- a/Assets/02. Scripts/Story/Managers/SoundManager.cs
+++ b/Assets/02. Scripts/Story/Managers/SoundManager.cs
@@ -1,5 +1,13 @@
+using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.UI;
+
+// 오디오 종류
+public enum SoundType
+{
+    Bgm,        // 배경음악
+    Effect,     // 효과음
+}
 
 public class SoundManager : MonoBehaviour
 {
@@ -29,40 +37,6 @@ public class SoundManager : MonoBehaviour
     private AudioSource[] bgmSources;
     [SerializeField]
     private AudioSource[] effectSources;
-
-    private void AssignAudioComponent()
-    {
-        // 모든 컴포넌트를 가져온다.
-        AudioSource[] audioSources = GetComponents<AudioSource>();
-
-        // 모자라면 재생기를 생성한다.
-        if (audioSources.Length < bgmAudioCount + effectAudioCount)
-        {
-            // 모자란 만큼 생성
-            for(int i = audioSources.Length; i < bgmAudioCount + effectAudioCount; ++i)
-            {
-                gameObject.AddComponent<AudioSource>();
-            }
-
-            // 다시 컴포넌트들을 가져온다.
-            audioSources = GetComponents<AudioSource>();
-        }
-
-
-        // BGM 재생기 할당
-        bgmSources = new AudioSource[bgmAudioCount];
-        for (int i = 0; i < bgmAudioCount; ++i)
-        {
-            bgmSources[i] = audioSources[i];
-        }
-
-        // 효과음 재생기 할당
-        effectSources = new AudioSource[effectAudioCount];
-        for (int i = 0; i < effectAudioCount; ++i)
-        {
-            effectSources[i] = audioSources[bgmAudioCount + i - 1];
-        }
-    }
 
     private void Awake()
     {
@@ -165,4 +139,84 @@ public class SoundManager : MonoBehaviour
 
         ApplyVolumeSettings();
     }
+
+    #region 오디오 재생
+    private void AssignAudioComponent()
+    {
+        // 모든 컴포넌트를 가져온다.
+        AudioSource[] audioSources = GetComponents<AudioSource>();
+
+        // 모자라면 재생기를 생성한다.
+        if (audioSources.Length < bgmAudioCount + effectAudioCount)
+        {
+            // 모자란 만큼 생성
+            for (int i = audioSources.Length; i < bgmAudioCount + effectAudioCount; ++i)
+            {
+                gameObject.AddComponent<AudioSource>();
+            }
+
+            // 다시 컴포넌트들을 가져온다.
+            audioSources = GetComponents<AudioSource>();
+        }
+
+
+        // BGM 재생기 할당
+        bgmSources = new AudioSource[bgmAudioCount];
+        for (int i = 0; i < bgmAudioCount; ++i)
+        {
+            bgmSources[i] = audioSources[i];
+        }
+
+        // 효과음 재생기 할당
+        effectSources = new AudioSource[effectAudioCount];
+        for (int i = 0; i < effectAudioCount; ++i)
+        {
+            effectSources[i] = audioSources[bgmAudioCount + i - 1];
+        }
+    }
+
+    // 현재 쉬고 있는 AudioSource를 찾아 반환한다.
+    private AudioSource GetIdleAudioSource(AudioSource[] audioSources)
+    {
+        // 모든 오디오 소스 중에
+        for (int i = 0; i < audioSources.Length; ++i)
+        {
+            // 재생 중이지 않은 오디오 소스를 찾아서
+            if (audioSources[i].isPlaying == false)
+            {
+                // 반환한다.
+                return audioSources[i];
+            }
+        }
+
+        // 모두 재생 중이라면, 에러를 띄우고 null을 반환한다.
+        Debug.LogError("모든 오디오 소스가 재생 중입니다!");
+        return null;
+    }
+
+    // 오디오 클립을 재생한다.
+    public void Play(AudioClip audioClip, SoundType type = SoundType.Effect, bool isLooping = false)
+    {
+        AudioSource currentSource;
+
+        if (type == SoundType.Bgm)
+        {
+            currentSource = GetIdleAudioSource(bgmSources);
+            // 출력 믹서 변경
+            // currentSource.outputAudioMixerGroup = ;
+        }
+
+        else
+        {
+            currentSource = GetIdleAudioSource(effectSources);
+            // 출력 믹서 변경
+            // currentSource.outputAudioMixerGroup = ;
+        }
+
+        currentSource.clip = audioClip;
+        currentSource.loop = isLooping;
+
+        currentSource.Play();
+    }
+    #endregion 오디오 재생
 }

--- a/Assets/02. Scripts/Story/Managers/SoundManager.cs
+++ b/Assets/02. Scripts/Story/Managers/SoundManager.cs
@@ -30,11 +30,11 @@ public class SoundManager : MonoBehaviour
 
     [Header("재생")]
     // BGM 재생기 개수
-    private const int bgmAudioCount = 1;
+    private const int bgmAudioCount = 1;    // 무조건 하나로 제한하겠습니다.
     private const int effectAudioCount = 5;
 
     [SerializeField]
-    private AudioSource[] bgmSources;
+    private AudioSource bgmSource;
     [SerializeField]
     private AudioSource[] effectSources;
 
@@ -161,17 +161,13 @@ public class SoundManager : MonoBehaviour
 
 
         // BGM 재생기 할당
-        bgmSources = new AudioSource[bgmAudioCount];
-        for (int i = 0; i < bgmAudioCount; ++i)
-        {
-            bgmSources[i] = audioSources[i];
-        }
+        bgmSource = audioSources[0];
 
         // 효과음 재생기 할당
         effectSources = new AudioSource[effectAudioCount];
         for (int i = 0; i < effectAudioCount; ++i)
         {
-            effectSources[i] = audioSources[bgmAudioCount + i - 1];
+            effectSources[i] = audioSources[i + bgmAudioCount];
         }
     }
 
@@ -201,16 +197,32 @@ public class SoundManager : MonoBehaviour
 
         if (type == SoundType.Bgm)
         {
-            currentSource = GetIdleAudioSource(bgmSources);
+            // 같은 클립이 재생 중이라면
+            if (audioClip == bgmSource.clip)
+            {
+                // 중단한다.
+                return;
+            }
+
+            // 그 외엔 BGM 소스 선택
+            currentSource = bgmSource;
             // 출력 믹서 변경
             // currentSource.outputAudioMixerGroup = ;
         }
 
         else
         {
+            // 쉬고 있는 오디오 소스를 찾는다.
             currentSource = GetIdleAudioSource(effectSources);
             // 출력 믹서 변경
             // currentSource.outputAudioMixerGroup = ;
+        }
+
+        // 재생 가능 소스가 없다면 에러 메세지를 띄우고 중단
+        if(currentSource == null)
+        {
+            Debug.LogError("재생에 실패하였습니다.");
+            return;
         }
 
         currentSource.clip = audioClip;


### PR DESCRIPTION
## 개요
<!-- 어떤 점이 변경되었는지, 간단하게 작성해주세요. -->
- SoundManager에 Play 함수를 추가해, 원하는 시점에 원하는 AudioClip을 재생할 수 있게 구현했습니다.

## 변경 사항
<!-- 어떤 점에 변경되었는지 상세하게 작성해주세요.
### 카드 사용 구현
- 카드를 클릭 시 해당 카드가 커지며 강조됩니다. 카드를 적 또는 플레이어 오브젝트에 드래그하면 사용되며, 다른 곳에 드래그 시 취소됩니다.
-->
### 오디오 재생
- SoundManager 함수 내 Play 함수를 추가해, 어디서든 음악을 재생할 수 있게 구현했습니다.
  - Play 함수는 AudioClip, SoundType, isLooping을 변수로 받습니다.
  - BGM은 오직 1개의 음악만 재생 가능하며, 기존 재생 중이던 다른 음악이 있다면 중단 후 재생합니다.
  - Effect는 최대 5개의 음악을 재생 가능하며, 이 숫자는 effectAudioCount로 조정할 수 있습니다.
  - Effect는 음악을 겹쳐서 재생할 수 있으며, 내부적으로 **컴포넌트 단위의 오브젝트 풀링**을 사용합니다.

## 참고 자료
<!-- 기능 개발에 참고한 자료가 있다면 작성해주세요. (필수는 아닙니다.) -->
- https://midason.tistory.com/107
  - 여러 효과음이 겹칠 수 있어야 함을 알게 됨
- https://janjanland.tistory.com/10
  - 3D 세팅과 2D 세팅의 차이 참고