### PR TITLE
Feature/카드 보상

### DIFF
--- a/Assets/02. Scripts/Battle/Cards/Card SO/Bandage.asset
+++ b/Assets/02. Scripts/Battle/Cards/Card SO/Bandage.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   description: "4\uC758 \uCCB4\uB825\uC744 \uD68C\uBCF5\uD569\uB2C8\uB2E4."
   sprite: {fileID: 21300000, guid: 0c2f54e7a1d93ce45a171225b6c8ac85, type: 3}
   skills:
-  - type: 9
+  - type: 2
     target: 0
     amount: 4
     turnCount: 3

--- a/Assets/02. Scripts/Battle/Cards/Card SO/Bat.asset
+++ b/Assets/02. Scripts/Battle/Cards/Card SO/Bat.asset
@@ -12,21 +12,21 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ee4e1de6682e5bb448d13b0b62311c21, type: 3}
   m_Name: Bat
   m_EditorClassIdentifier: 
-  name: "\uC57C\uAD6C\uBC29\uB9DD\uC774"
-  description: "\uC801\uC5D0\uAC8C \uD53C\uD574\uB97C damage0 \uC785\uD788\uACE0
-    3\uD134 \uAC04 \uCD9C\uD608\uC744 \uBD80\uC5EC\uD569\uB2C8\uB2E4."
+  name: "\uC57C\uAD6C \uBC29\uB9DD\uC774"
+  description: "2\uD134 \uB3D9\uC548 \uACF5\uACA9\uB825\uC774 2 \uC99D\uAC00\uD558\uACE0
+    \uC801\uC5D0\uAC8C damage1\uC758 \uD53C\uD574\uB97C \uC90D\uB2C8\uB2E4."
   sprite: {fileID: 21300000, guid: a5507f2c6306af042bb67f480bffb3a5, type: 3}
   skills:
+  - type: 12
+    target: 0
+    amount: 2
+    turnCount: 2
+    effectPrefeb: {fileID: 0}
+    sound: {fileID: 0}
   - type: 0
     target: 1
-    amount: 10
+    amount: 8
     turnCount: 0
     effectPrefeb: {fileID: 2022655609410639260, guid: 77ea7d364b7273341a070bbbc89626a2, type: 3}
     sound: {fileID: 8300000, guid: f6b53edc268c44e479b6323c104a9afb, type: 3}
-  - type: 10
-    target: 1
-    amount: 2
-    turnCount: 3
-    effectPrefeb: {fileID: 0}
-    sound: {fileID: 0}
-  cost: 4
+  cost: 3

--- a/Assets/02. Scripts/Battle/Cards/Card SO/Bite.asset
+++ b/Assets/02. Scripts/Battle/Cards/Card SO/Bite.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Bite
   m_EditorClassIdentifier: 
   name: "\uBB3C\uC5B4\uB72F\uAE30 \uAF2C\uC9D1\uAE30 \uAE68\uBB3C\uAE30"
-  description: "\uC801\uC5D0\uAC8C damage0\uC758 \uB370\uBBF8\uC9C0\uB97C 3\uBC88
-    \uC785\uD799\uB2C8\uB2E4."
+  description: "\uC801\uC5D0\uAC8C damage0\uC758 \uD53C\uD574\uB97C 3\uBC88 \uC90D\uB2C8\uB2E4."
   sprite: {fileID: 21300000, guid: e39fd3030c937bd40a052863438b0cd1, type: 3}
   skills:
   - type: 0
@@ -22,14 +21,17 @@ MonoBehaviour:
     amount: 5
     turnCount: 0
     effectPrefeb: {fileID: 508783932658678992, guid: efc8fa89c5a0a6e40a4ccf6f2b114223, type: 3}
+    sound: {fileID: 0}
   - type: 0
     target: 1
     amount: 5
     turnCount: 0
     effectPrefeb: {fileID: 6898238570730899697, guid: 3c6884803ff0c444d8aa3a83e11a109e, type: 3}
+    sound: {fileID: 0}
   - type: 0
     target: 1
     amount: 5
     turnCount: 0
     effectPrefeb: {fileID: 508783932658678992, guid: efc8fa89c5a0a6e40a4ccf6f2b114223, type: 3}
+    sound: {fileID: 0}
   cost: 3

--- a/Assets/02. Scripts/Battle/Cards/Card SO/Chain Saw.asset
+++ b/Assets/02. Scripts/Battle/Cards/Card SO/Chain Saw.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Chain Saw
   m_EditorClassIdentifier: 
   name: "\uCCB4\uC778 \uC18C\uC6B0"
-  description: "\uC801\uC5D0\uAC8C damage0\uC758 \uB370\uBBF8\uC9C0\uB97C \uC785\uD788\uACE0
+  description: "\uC801\uC5D0\uAC8C damage0\uC758 \uD53C\uD574\uB97C \uC8FC\uACE0
     3\uD134 \uB3D9\uC548 \uCD9C\uD608\uC744 \uBD80\uC5EC\uD569\uB2C8\uB2E4."
   sprite: {fileID: 21300000, guid: 8160122a34f6ec544a554bfcd93a055b, type: 3}
   skills:

--- a/Assets/02. Scripts/Battle/Cards/Card SO/Drain.asset
+++ b/Assets/02. Scripts/Battle/Cards/Card SO/Drain.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Drain
   m_EditorClassIdentifier: 
   name: "\uD761\uD608"
-  description: "\uC801\uC5D0\uAC8C damage0\uC758 \uB370\uBBF8\uC9C0\uB97C \uC90D\uB2C8\uB2E4.
+  description: "\uC801\uC5D0\uAC8C damage0\uC758 \uD53C\uD574\uB97C \uC90D\uB2C8\uB2E4.
     \uAC00\uD55C \uB370\uBBF8\uC9C0 \uB9CC\uD07C \uCCB4\uB825\uC744 \uD68C\uBCF5\uD569\uB2C8\uB2E4."
   sprite: {fileID: 21300000, guid: 3cc44a5f66759334596156425c08df11, type: 3}
   skills:

--- a/Assets/02. Scripts/Battle/Cards/Card SO/Fist.asset
+++ b/Assets/02. Scripts/Battle/Cards/Card SO/Fist.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Fist
   m_EditorClassIdentifier: 
   name: "\uC804\uD1B5\uC801\uC778 \uBB34\uAE30"
-  description: "\uC801\uC5D0\uAC8C damage0\uC758 \uB370\uBBF8\uC9C0\uB97C \uC785\uD799\uB2C8\uB2E4."
+  description: "\uC801\uC5D0\uAC8C damage0\uC758 \uD53C\uD574\uB97C \uC90D\uB2C8\uB2E4."
   sprite: {fileID: 21300000, guid: c25cce27aabacb244ac09732a687a062, type: 3}
   skills:
   - type: 0

--- a/Assets/02. Scripts/Battle/Cards/Card SO/Flask.asset
+++ b/Assets/02. Scripts/Battle/Cards/Card SO/Flask.asset
@@ -13,8 +13,8 @@ MonoBehaviour:
   m_Name: Flask
   m_EditorClassIdentifier: 
   name: "\uC2DC\uC57D \uD22C\uCC99"
-  description: "\uBAA8\uB4E0 \uC801\uC5D0\uAC8C damage0\uC758 \uB370\uBBF8\uC9C0\uB97C
-    \uC785\uD799\uB2C8\uB2E4."
+  description: "\uBAA8\uB4E0 \uC801\uC5D0\uAC8C damage0\uC758 \uD53C\uD574\uB97C
+    \uC90D\uB2C8\uB2E4."
   sprite: {fileID: 21300000, guid: 305f554915ca0e547b5bd099653a071e, type: 3}
   skills:
   - type: 0

--- a/Assets/02. Scripts/Battle/Cards/Card SO/Fragile Glass.asset
+++ b/Assets/02. Scripts/Battle/Cards/Card SO/Fragile Glass.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Fragile Glass
   m_EditorClassIdentifier: 
   name: "\uAE68\uC9C4 \uC720\uB9AC"
-  description: "\uC801\uC5D0\uAC8C damage0\uC758 \uB370\uBBF8\uC9C0\uB97C \uC785\uD788\uACE0,
+  description: "\uC801\uC5D0\uAC8C damage0\uC758 \uD53C\uD574\uB97C \uC8FC\uACE0,
     \uD50C\uB808\uC774\uC5B4\uB294 3\uD134 \uB3D9\uC548 \uCD9C\uD608\uC744 \uBC1B\uC2B5\uB2C8\uB2E4."
   sprite: {fileID: 21300000, guid: 9ea4cba2afeaf0243bc65e23c261ea2e, type: 3}
   skills:

--- a/Assets/02. Scripts/Battle/Cards/Card SO/IED.asset
+++ b/Assets/02. Scripts/Battle/Cards/Card SO/IED.asset
@@ -13,8 +13,8 @@ MonoBehaviour:
   m_Name: IED
   m_EditorClassIdentifier: 
   name: I.E.D
-  description: "\uBAA8\uB4E0 \uC801\uC5D0\uAC8C damage0\uC758 \uB370\uBBF8\uC9C0\uB97C
-    \uC785\uD799\uB2C8\uB2E4."
+  description: "\uBAA8\uB4E0 \uC801\uC5D0\uAC8C damage0\uC758 \uD53C\uD574\uB97C
+    \uC90D\uB2C8\uB2E4."
   sprite: {fileID: 21300000, guid: fde6c4a20c6fc5a4d97166b3209be209, type: 3}
   skills:
   - type: 0

--- a/Assets/02. Scripts/Battle/Cards/Card SO/Knife Fight.asset
+++ b/Assets/02. Scripts/Battle/Cards/Card SO/Knife Fight.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Knife Fight
   m_EditorClassIdentifier: 
   name: "\uB2E8\uAC80\uC220"
-  description: "\uC801\uC5D0\uAC8C damage0\uC758 \uD53C\uD574\uB97C 2\uBC88 \uC785\uD799\uB2C8\uB2E4"
+  description: "\uC801\uC5D0\uAC8C damage0\uC758 \uD53C\uD574\uB97C 2\uBC88 \uC90D\uB2C8\uB2E4."
   sprite: {fileID: 0}
   skills:
   - type: 0
@@ -21,9 +21,11 @@ MonoBehaviour:
     amount: 6
     turnCount: 0
     effectPrefeb: {fileID: 6898238570730899697, guid: 3c6884803ff0c444d8aa3a83e11a109e, type: 3}
+    sound: {fileID: 0}
   - type: 0
     target: 1
     amount: 6
     turnCount: 0
     effectPrefeb: {fileID: 6898238570730899697, guid: 4f62aa7f6574fc9468d1100cba3643f1, type: 3}
+    sound: {fileID: 0}
   cost: 2

--- a/Assets/02. Scripts/Battle/Cards/Card SO/Rusty Knife.asset
+++ b/Assets/02. Scripts/Battle/Cards/Card SO/Rusty Knife.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Rusty Knife
   m_EditorClassIdentifier: 
   name: "\uB179\uC2A8 \uB3C4\uC2E0"
-  description: "\uC801\uC5D0\uAC8C damage0\uC758 \uB370\uBBF8\uC9C0\uB97C \uC785\uD788\uACE0
+  description: "\uC801\uC5D0\uAC8C damage0\uC758 \uD53C\uD574\uB97C \uC8FC\uACE0
     3\uD134 \uB3D9\uC548 \uCD9C\uD608\uC744 \uBD80\uC5EC\uD569\uB2C8\uB2E4."
   sprite: {fileID: 21300000, guid: 7853c5278e20fbb4494019e3b82c3509, type: 3}
   skills:

--- a/Assets/02. Scripts/Battle/Cards/Card SO/Scalpel.asset
+++ b/Assets/02. Scripts/Battle/Cards/Card SO/Scalpel.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Scalpel
   m_EditorClassIdentifier: 
   name: "\uC6A9\uB3C4 \uC678 \uC0AC\uC6A9"
-  description: "\uC801\uC5D0\uAC8C damage0\uC758 \uB370\uBBF8\uC9C0\uB97C \uC785\uD788\uACE0
+  description: "\uC801\uC5D0\uAC8C damage0\uC758 \uD53C\uD574\uB97C \uC8FC\uACE0
     3\uD134 \uB3D9\uC548 \uCD9C\uD608\uC744 \uBD80\uC5EC\uD569\uB2C8\uB2E4."
   sprite: {fileID: 21300000, guid: 9331792a6fb776940914cda6d5123841, type: 3}
   skills:

--- a/Assets/02. Scripts/Battle/Cards/Card SO/Stim Pack.asset
+++ b/Assets/02. Scripts/Battle/Cards/Card SO/Stim Pack.asset
@@ -18,7 +18,7 @@ MonoBehaviour:
   skills:
   - type: 12
     target: 0
-    amount: 2
+    amount: 3
     turnCount: 4
     effectPrefeb: {fileID: 3675006101537835259, guid: 2e5ad2beaf55e9f4b9c3ebc4a7a2d823, type: 3}
     sound: {fileID: 8300000, guid: df5631dd526110d498a66f70635c5a24, type: 3}

--- a/Assets/02. Scripts/Battle/Cards/Card SO/Stinger.asset
+++ b/Assets/02. Scripts/Battle/Cards/Card SO/Stinger.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Stinger
   m_EditorClassIdentifier: 
   name: "\uB3C5\uCE68"
-  description: "\uC801\uC5D0\uAC8C \uD53C\uD574\uB97C damage0 \uC785\uD788\uACE0
+  description: "\uC801\uC5D0\uAC8C damage0\uC758 \uD53C\uD574\uB97C \uC8FC\uACE0
     3\uD134 \uAC04 \uCD9C\uD608\uC744 \uBD80\uC5EC\uD569\uB2C8\uB2E4."
   sprite: {fileID: 21300000, guid: c9d53721d2421af4fbe5308ec0562444, type: 3}
   skills:

--- a/Assets/02. Scripts/Battle/Cards/Card SO/Stone.asset
+++ b/Assets/02. Scripts/Battle/Cards/Card SO/Stone.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Stone
   m_EditorClassIdentifier: 
   name: "\uC9F1\uB3CC"
-  description: "\uC801\uC5D0\uAC8C damage0\uC758 \uB370\uBBF8\uC9C0\uB97C \uC785\uD799\uB2C8\uB2E4."
+  description: "\uC801\uC5D0\uAC8C damage0\uC758 \uD53C\uD574\uB97C \uC90D\uB2C8\uB2E4."
   sprite: {fileID: 21300000, guid: 33ccc4e024f969e45b38f798bf715ec2, type: 3}
   skills:
   - type: 0

--- a/Assets/02. Scripts/Battle/Cards/Card SO/Warrant.asset
+++ b/Assets/02. Scripts/Battle/Cards/Card SO/Warrant.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Warrant
   m_EditorClassIdentifier: 
   name: "\uC601\uC7A5 \uBC1C\uBD80"
-  description: "\uB2E4\uC74C \uCE74\uB4DC\uC758 \uCF54\uC2A4\uD2B8\uAC00 2 \uAC10\uC18C\uD569\uB2C8\uB2E4"
+  description: "\uB2E4\uC74C \uCE74\uB4DC\uC758 \uCF54\uC2A4\uD2B8\uAC00 2 \uAC10\uC18C\uD569\uB2C8\uB2E4."
   sprite: {fileID: 21300000, guid: 3cc44a5f66759334596156425c08df11, type: 3}
   skills:
   - type: 13

--- a/Assets/02. Scripts/Battle/Cards/Deck SO/Reward Card List/Level 1.5.asset
+++ b/Assets/02. Scripts/Battle/Cards/Deck SO/Reward Card List/Level 1.5.asset
@@ -12,11 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7f3fb2f9dcc44ce4682722928048a3fe, type: 3}
   m_Name: Level 1.5
   m_EditorClassIdentifier: 
-  listName: Level 1
+  listName: Level 1.5
   items:
-  - {fileID: 11400000, guid: 902cc778acf176046bc96027f5665db0, type: 2}
-  - {fileID: 11400000, guid: 664cee9063f13b74eab292f2006f6fd9, type: 2}
-  - {fileID: 11400000, guid: ea49938c693a62143936eb71b7b7478a, type: 2}
   - {fileID: 11400000, guid: f723210fe5c869a49ae1500d7bb38094, type: 2}
   - {fileID: 11400000, guid: 2c7455992dcc55240a49fb93a61a21f0, type: 2}
   - {fileID: 11400000, guid: 616050dc92e75b14e82cf5ccf5943a65, type: 2}
@@ -25,3 +22,6 @@ MonoBehaviour:
   - {fileID: 11400000, guid: f342696b5dfe28c4cb24b29993e1e0bb, type: 2}
   - {fileID: 11400000, guid: d9b2012e89f0fbf4eb57d3cbbf2f991f, type: 2}
   - {fileID: 11400000, guid: b07af47d89774ee49bdcdea07d17c8ef, type: 2}
+  - {fileID: 11400000, guid: 9c9b57395b10fd74599c6443fc6a79d7, type: 2}
+  - {fileID: 11400000, guid: e3e9cf104d54add4b8b4869fc0f6eb92, type: 2}
+  - {fileID: 11400000, guid: 3d566dab9eebf8f49aaad0449f2b1c7b, type: 2}

--- a/Assets/02. Scripts/Battle/Cards/Deck SO/Reward Card List/Level 1.5.asset
+++ b/Assets/02. Scripts/Battle/Cards/Deck SO/Reward Card List/Level 1.5.asset
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f3fb2f9dcc44ce4682722928048a3fe, type: 3}
+  m_Name: Level 1.5
+  m_EditorClassIdentifier: 
+  listName: Level 1
+  items:
+  - {fileID: 11400000, guid: 902cc778acf176046bc96027f5665db0, type: 2}
+  - {fileID: 11400000, guid: 664cee9063f13b74eab292f2006f6fd9, type: 2}
+  - {fileID: 11400000, guid: ea49938c693a62143936eb71b7b7478a, type: 2}
+  - {fileID: 11400000, guid: f723210fe5c869a49ae1500d7bb38094, type: 2}
+  - {fileID: 11400000, guid: 2c7455992dcc55240a49fb93a61a21f0, type: 2}
+  - {fileID: 11400000, guid: 616050dc92e75b14e82cf5ccf5943a65, type: 2}
+  - {fileID: 11400000, guid: ac32f79312052cd4287bc9ece89c4d18, type: 2}
+  - {fileID: 11400000, guid: 9d2c144da0aa4774e9c3bc7294f55962, type: 2}
+  - {fileID: 11400000, guid: f342696b5dfe28c4cb24b29993e1e0bb, type: 2}
+  - {fileID: 11400000, guid: d9b2012e89f0fbf4eb57d3cbbf2f991f, type: 2}
+  - {fileID: 11400000, guid: b07af47d89774ee49bdcdea07d17c8ef, type: 2}

--- a/Assets/02. Scripts/Battle/Cards/Deck SO/Reward Card List/Level 1.5.asset.meta
+++ b/Assets/02. Scripts/Battle/Cards/Deck SO/Reward Card List/Level 1.5.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a9f6b58227b5a0e4bb97c884545f4146
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/02. Scripts/Battle/Cards/Deck SO/Reward Card List/Level 1.asset
+++ b/Assets/02. Scripts/Battle/Cards/Deck SO/Reward Card List/Level 1.asset
@@ -14,19 +14,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   listName: Level 1
   items:
-  - {fileID: 11400000, guid: ac32f79312052cd4287bc9ece89c4d18, type: 2}
-  - {fileID: 11400000, guid: 5486b1e3e1685b049b28e26db764145f, type: 2}
-  - {fileID: 11400000, guid: 9d2c144da0aa4774e9c3bc7294f55962, type: 2}
-  - {fileID: 11400000, guid: 616050dc92e75b14e82cf5ccf5943a65, type: 2}
   - {fileID: 11400000, guid: 902cc778acf176046bc96027f5665db0, type: 2}
-  - {fileID: 11400000, guid: b07af47d89774ee49bdcdea07d17c8ef, type: 2}
-  - {fileID: 11400000, guid: f342696b5dfe28c4cb24b29993e1e0bb, type: 2}
-  - {fileID: 11400000, guid: ea49938c693a62143936eb71b7b7478a, type: 2}
-  - {fileID: 11400000, guid: 2b098fed143c4b44fb18fc2423d847b3, type: 2}
-  - {fileID: 11400000, guid: d9b2012e89f0fbf4eb57d3cbbf2f991f, type: 2}
-  - {fileID: 11400000, guid: 3d566dab9eebf8f49aaad0449f2b1c7b, type: 2}
-  - {fileID: 11400000, guid: db3bd501b67001e4f8c14953287417ac, type: 2}
-  - {fileID: 11400000, guid: dc18f59901d44824a9c3ac03983ac960, type: 2}
-  - {fileID: 11400000, guid: a02a150c2dbd3d94781b7c459ba7be76, type: 2}
-  - {fileID: 11400000, guid: 5cb0d93a4abf916429d5fa861ee2ea9c, type: 2}
   - {fileID: 11400000, guid: 664cee9063f13b74eab292f2006f6fd9, type: 2}
+  - {fileID: 11400000, guid: ea49938c693a62143936eb71b7b7478a, type: 2}
+  - {fileID: 11400000, guid: f723210fe5c869a49ae1500d7bb38094, type: 2}
+  - {fileID: 11400000, guid: 2c7455992dcc55240a49fb93a61a21f0, type: 2}
+  - {fileID: 11400000, guid: 616050dc92e75b14e82cf5ccf5943a65, type: 2}
+  - {fileID: 11400000, guid: ac32f79312052cd4287bc9ece89c4d18, type: 2}
+  - {fileID: 11400000, guid: 9d2c144da0aa4774e9c3bc7294f55962, type: 2}
+  - {fileID: 11400000, guid: f342696b5dfe28c4cb24b29993e1e0bb, type: 2}
+  - {fileID: 11400000, guid: d9b2012e89f0fbf4eb57d3cbbf2f991f, type: 2}
+  - {fileID: 11400000, guid: b07af47d89774ee49bdcdea07d17c8ef, type: 2}

--- a/Assets/02. Scripts/Battle/Cards/Deck SO/Reward Card List/Level 2.asset
+++ b/Assets/02. Scripts/Battle/Cards/Deck SO/Reward Card List/Level 2.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f3fb2f9dcc44ce4682722928048a3fe, type: 3}
+  m_Name: Level 2
+  m_EditorClassIdentifier: 
+  listName: Level 2
+  items:
+  - {fileID: 11400000, guid: 3d566dab9eebf8f49aaad0449f2b1c7b, type: 2}
+  - {fileID: 11400000, guid: fa1853870e9e8d04c8edf439eddf109a, type: 2}
+  - {fileID: 11400000, guid: bf21aebdf8de4e6469ac7bb675402bc9, type: 2}
+  - {fileID: 11400000, guid: 2b098fed143c4b44fb18fc2423d847b3, type: 2}
+  - {fileID: 11400000, guid: e3e9cf104d54add4b8b4869fc0f6eb92, type: 2}
+  - {fileID: 11400000, guid: 86df1af27f4057c47a30838cddccebcf, type: 2}
+  - {fileID: 11400000, guid: 9c9b57395b10fd74599c6443fc6a79d7, type: 2}
+  - {fileID: 11400000, guid: d9b2012e89f0fbf4eb57d3cbbf2f991f, type: 2}
+  - {fileID: 11400000, guid: f723210fe5c869a49ae1500d7bb38094, type: 2}

--- a/Assets/02. Scripts/Battle/Cards/Deck SO/Reward Card List/Level 2.asset.meta
+++ b/Assets/02. Scripts/Battle/Cards/Deck SO/Reward Card List/Level 2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9844c53f531144a49881128b55c150a0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/02. Scripts/Battle/Cards/Deck SO/Reward Card List/Level 3.asset
+++ b/Assets/02. Scripts/Battle/Cards/Deck SO/Reward Card List/Level 3.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f3fb2f9dcc44ce4682722928048a3fe, type: 3}
+  m_Name: Level 3
+  m_EditorClassIdentifier: 
+  listName: Level 3
+  items:
+  - {fileID: 11400000, guid: 488a3facba9c6f74fa34a5a1e7c8ddb0, type: 2}
+  - {fileID: 11400000, guid: a02a150c2dbd3d94781b7c459ba7be76, type: 2}
+  - {fileID: 11400000, guid: 5cb0d93a4abf916429d5fa861ee2ea9c, type: 2}
+  - {fileID: 11400000, guid: db3bd501b67001e4f8c14953287417ac, type: 2}

--- a/Assets/02. Scripts/Battle/Cards/Deck SO/Reward Card List/Level 3.asset.meta
+++ b/Assets/02. Scripts/Battle/Cards/Deck SO/Reward Card List/Level 3.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fbd16af257ce1cd4b803f1a1ed3d843a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/02. Scripts/Battle/Character/Enemy/Enemy SO/Thief.asset
+++ b/Assets/02. Scripts/Battle/Character/Enemy/Enemy SO/Thief.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9329a161b0565444b9bfb0e43ad8ee1e, type: 3}
+  m_Name: Thief
+  m_EditorClassIdentifier: 
+  enemyId: Thief
+  illust: {fileID: 21300000, guid: a1a392017f7cb9d46b1781e3956c5fe5, type: 3}
+  maxHp: 23
+  skills:
+  - type: 0
+    target: 0
+    amount: 7
+    turnCount: 0
+    effectPrefeb: {fileID: 0}
+    sound: {fileID: 0}
+  - type: 0
+    target: 0
+    amount: 11
+    turnCount: 0
+    effectPrefeb: {fileID: 0}
+    sound: {fileID: 0}

--- a/Assets/02. Scripts/Battle/Character/Enemy/Enemy SO/Thief.asset.meta
+++ b/Assets/02. Scripts/Battle/Character/Enemy/Enemy SO/Thief.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c7be67cfef8c0584ab5c3dfd7b2d4313
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 개요
<!-- 어떤 점이 변경되었는지, 간단하게 작성해주세요. -->
보상 카드 리스트를 추가했습니다.
## 변경 사항
<!-- 어떤 점에 변경되었는지 상세하게 작성해주세요.
### 카드 사용 구현
- 카드를 클릭 시 해당 카드가 커지며 강조됩니다. 카드를 적 또는 플레이어 오브젝트에 드래그하면 사용되며, 다른 곳에 드래그 시 취소됩니다.
-->
- 카드 설명의 컨벤션을 통일했습니다.
- Level 1, 1.5, 2, 3으로 구성해 리스트를 분류했습니다.
- CSV에 전투의 난이도에 따라 높은 레벨의 리스트를 표시하도록 수정했습니다.
- Theif Enemy SO를 추가했습니다.
## 참고 자료
<!-- 기능 개발에 참고한 자료가 있다면 작성해주세요. (필수는 아닙니다.) -->
